### PR TITLE
Changed template

### DIFF
--- a/application/views/blocks/captcha_form.tpl
+++ b/application/views/blocks/captcha_form.tpl
@@ -1,18 +1,3 @@
 [{$smarty.block.parent}]
 
-[{assign var="oCaptcha" value=$oView->getCaptcha()}]
-<input type="hidden" name="c_mach" value="[{$oCaptcha->getHash()}]"/>
-
-<li class="verify">
-  <label class="req">[{oxmultilang ident="VERIFICATION_CODE" suffix="COLON"}]</label>
-  [{assign var="oCaptcha" value=$oView->getCaptcha()}]
-  [{if $oCaptcha->isImageVisible()}]
-    <img src="[{$oCaptcha->getImageUrl()}]" alt="">
-  [{else}]
-    <span class="verificationCode" id="verifyTextCode">[{$oCaptcha->getText()}]</span>
-  [{/if}]
-  <input type="text" data-fieldsize="verify" name="c_mac" value="" class="js-oxValidate js-oxValidate_notEmpty">
-  <p class="oxValidateError">
-    <span class="js-oxError_notEmpty">[{oxmultilang ident="ERROR_MESSAGE_INPUT_NOTALLFIELDS"}]</span>
-  </p>
-</li>
+[{include file="oecaptcha.tpl"}]

--- a/application/views/tpl/oecaptcha.tpl
+++ b/application/views/tpl/oecaptcha.tpl
@@ -15,7 +15,5 @@
             </span>
             <input type="text" data-fieldsize="verify" name="c_mac" value="" class="form-control js-oxValidate js-oxValidate_notEmpty" required>
         </div>
-
-        <div class="help-block"}]
     </div>
 </div>

--- a/application/views/tpl/oecaptcha.tpl
+++ b/application/views/tpl/oecaptcha.tpl
@@ -1,0 +1,21 @@
+[{assign var="oCaptcha" value=$oView->getCaptcha()}]
+<input type="hidden" name="c_mach" value="[{$oCaptcha->getHash()}]"/>
+
+<div class="form-group verify">
+    <label class="req control-label col-lg-2" for="c_mac">[{oxmultilang ident="VERIFICATION_CODE"}]</label>
+
+    <div class="col-lg-10 controls">
+        <div class="input-group">
+            <span class="input-group-addon">
+                [{if $oCaptcha->isImageVisible()}]
+                    <img src="[{$oCaptcha->getImageUrl()}]" alt="">
+                [{else}]
+                    <span class="verificationCode" id="verifyTextCode">[{$oCaptcha->getText()}]</span>
+                [{/if}]
+            </span>
+            <input type="text" data-fieldsize="verify" name="c_mac" value="" class="form-control js-oxValidate js-oxValidate_notEmpty" required>
+        </div>
+
+        <div class="help-block"}]
+    </div>
+</div>

--- a/metadata.php
+++ b/metadata.php
@@ -47,7 +47,9 @@ $aModule = array(
         'oecaptcha'       => 'oe/captcha/core/oecaptcha.php',
         'oecaptchaEvents' => 'oe/captcha/core/oecaptchaevents.php',
     ),
-    'templates'   => array(),
+    'templates'   => array(
+        'oecaptcha.tpl' => 'oe/captcha/application/views/tpl/oecaptcha.tpl',
+    ),
     'blocks'      => array(
         array('template' => 'form/contact.tpl', 'block'=>'captcha_form', 'file'=>'/application/views/blocks/captcha_form.tpl'),
         array('template' => 'form/privatesales/invite.tpl', 'block'=>'captcha_form', 'file'=>'/application/views/blocks/captcha_form.tpl'),


### PR DESCRIPTION
- changed the default markup to match the oxid theme "flow"
- moved the markup from the block file to its own template, so it is overwriteable from the active theme