### PR TITLE
Fix: Curly brace access syntax is deprecated since PHP 7.4

### DIFF
--- a/core/oecaptcha.php
+++ b/core/oecaptcha.php
@@ -50,7 +50,7 @@ class oeCaptcha extends oxSuperCfg
         if (!$this->text) {
             $this->text = '';
             for ($i = 0; $i < $this->macLength; $i++) {
-                $this->text .= strtolower($this->macChars{rand(0, strlen($this->macChars) - 1)});
+                $this->text .= strtolower($this->macChars[rand(0, strlen($this->macChars) - 1)]);
             }
         }
 


### PR DESCRIPTION
Using this in projects using PHP >= 7.4 will fail. 